### PR TITLE
Update Readme and add Puppet 3.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ curl -sSL https://get.rvm.io | sudo bash -s stable
 rvm install ruby-2.0.0
 rvm alias create default ruby-2.0.0
 ```
+* Bundler installation for your RVM Ruby installation is required by the Puppet module:
+```bash
+gem install bundler
+```
 * Puppet Gem (3.4.0+) installation for your RVM Ruby installation:
 ```bash
 gem install puppet

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class puppet_stack::params {
   # 3.4.x because we use contain
-  validate_re($::puppetversion, '^3[.](4|5|6|7)[.]\d+', "Invalid Puppet version. The puppet_stack module will only run on versions that have been tested (=>3.4.x <=3.7.x) - version: ${::puppetversion}. Modify at your own risk.")
+  validate_re($::puppetversion, '^3[.](4|5|6|7|8)[.]\d+', "Invalid Puppet version. The puppet_stack module will only run on versions that have been tested (=>3.4.x <=3.7.x) - version: ${::puppetversion}. Modify at your own risk.")
   # Because 1.8.x should not be used anymore. They're all EOL!
   validate_re($::rubyversion, '^(1|2)[.][^8][.]\d+', "You should not be using Ruby ${::rubyversion} with this module. Please install a newer version of Ruby, or just use your available distro packages.")
 


### PR DESCRIPTION
- Puppet 3.8 support has been added by modifying the validate check in params.pp
- Readme has been updated to include the installation of bundler, my initial Puppet run failed due to this

Thanks for your module!

Regards,
Bas
